### PR TITLE
Fix bug in clean_game

### DIFF
--- a/annotator/__main__.py
+++ b/annotator/__main__.py
@@ -390,7 +390,7 @@ def clean_game(game):
 
         node.comment = None
         node.nags = []
-        for variation in node.variations:
+        for variation in reversed(node.variations):
             if not variation.is_main_variation():
                 node.remove_variation(variation)
 


### PR DESCRIPTION
I noticed a bug in `clean_game` in that if there is more than one variation, only the first is deleted because of deleting from a list during iteration. The fix was simple: use a reversed iterator to delete starting from the end instead.