### PR TITLE
Division by zero error if ply_count is zero

### DIFF
--- a/annotator/__main__.py
+++ b/annotator/__main__.py
@@ -540,7 +540,7 @@ def get_pass2_budget(total_budget, pass1_budget):
 
 
 def get_time_per_move(pass_budget, ply_count):
-    return float(pass_budget) / float(ply_count)
+    return float(pass_budget) / float(max(ply_count, 1))
 
 
 def analyze_game(game, arg_gametime, enginepath, threads):
@@ -702,7 +702,7 @@ def analyze_game(game, arg_gametime, enginepath, threads):
     except ZeroDivisionError:
         logger.debug("No errors found on first pass!")
         # There were no mistakes in the game, so deeply analyze all the moves
-        time_per_move = pass2_budget / ply_count
+        time_per_move = pass2_budget / max(ply_count, 1)
         node = game.end()
         while not node == root_node:
             prev_node = node.parent


### PR DESCRIPTION

Fixes #30 

When running the program, I sometimes ran into two different division by zero problems, caused by the fact that ply_count = 0. My solution is that the minimum of the division with ply_count is 1, so a division by zero is not possible.  I suppose it would be better to ensure that ply_count never is zero, but I'm not sure how hard that is as I haven't really looked into the problem.